### PR TITLE
ci: add riscv64 wheel build workflow

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -1,0 +1,111 @@
+name: Build riscv64 wheel
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Upstream release tag to build from'
+        required: false
+        type: string
+  schedule:
+    - cron: '0 2 * * 0'
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux, riscv64]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libyaml-dev
+
+      - name: Set up Python
+        run: |
+          python3 -m venv /tmp/build-venv
+          . /tmp/build-venv/bin/activate
+          pip install --upgrade pip setuptools wheel
+
+      - name: Build wheel
+        run: |
+          . /tmp/build-venv/bin/activate
+          pip wheel --no-deps --wheel-dir /tmp/wheels/ . 
+
+      - name: Verify platform tag
+        run: |
+          ls /tmp/wheels/*.whl
+          for whl in /tmp/wheels/*.whl; do
+            if echo "$whl" | grep -q "linux_riscv64\|manylinux.*riscv64"; then
+              echo "OK: $whl"
+            else
+              echo "FAIL: $whl does not have riscv64 platform tag"
+              exit 1
+            fi
+          done
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-riscv64
+          path: /tmp/wheels/*.whl
+          retention-days: 90
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf /tmp/build-venv /tmp/wheels
+
+  release:
+    needs: build
+    runs-on: [self-hosted, linux, riscv64]
+    if: success()
+    steps:
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel-riscv64
+          path: /tmp/wheels/
+
+      - name: Get wheel info
+        id: wheel_info
+        run: |
+          WHL=$(ls /tmp/wheels/*.whl | head -1)
+          BASENAME=$(basename "$WHL")
+          VERSION=$(echo "$BASENAME" | sed 's/^[^-]*-\([^-]*\)-.*/\1/')
+          echo "whl_path=$WHL" >> "$GITHUB_OUTPUT"
+          echo "whl_name=$BASENAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate checksums
+        run: |
+          cd /tmp/wheels
+          sha256sum *.whl > SHA256SUMS
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="riscv64-v${{ steps.wheel_info.outputs.version }}"
+          TITLE="riscv64 wheel v${{ steps.wheel_info.outputs.version }}"
+          gh release delete "$TAG" --yes 2>/dev/null || true
+          git tag -d "$TAG" 2>/dev/null || true
+          git push origin ":refs/tags/$TAG" 2>/dev/null || true
+          gh release create "$TAG"             --title "$TITLE"             --notes "Prebuilt riscv64 wheel for $(uname -m) Linux.
+
+          Built on: BananaPi F3 (SpacemiT K1, rv64imafdcv)
+          Python: $(python3 --version 2>&1)
+          Wheel: ${{ steps.wheel_info.outputs.whl_name }}
+
+          Install:
+          \`\`\`
+          pip install pyyaml --find-links https://github.com/gounthar/$(basename $PWD)/releases/download/$TAG/
+          \`\`\`"             /tmp/wheels/*.whl             /tmp/wheels/SHA256SUMS
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf /tmp/wheels


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to build riscv64 Python wheels on self-hosted runner
- Runs on schedule (weekly Sunday 2 AM UTC) and manual dispatch
- Builds wheel, verifies riscv64 platform tag, creates GitHub Release with checksums

## Build infrastructure

- Runner: BananaPi F3 (SpacemiT K1, 8x rv64imafdcv @ 1.6 GHz, 16 GB RAM)
- Labels: `self-hosted, linux, riscv64`

## Test plan

- [ ] Manually trigger `build-riscv64.yml` via workflow_dispatch
- [ ] Verify wheel is built with correct riscv64 platform tag
- [ ] Verify GitHub Release is created with wheel + SHA256SUMS