### PR TITLE
ci: notify central index after wheel release

### DIFF
--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -109,3 +109,17 @@ jobs:
       - name: Cleanup
         if: always()
         run: rm -rf /tmp/wheels
+  notify-index:
+    needs: release
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - name: Trigger index update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/gounthar/riscv64-python-wheels/dispatches \
+            -f event_type=fork-release-published \
+            -f "client_payload[repo]=${{ github.repository }}" \
+            -f "client_payload[tag]=${{ github.ref_name }}" || true
+


### PR DESCRIPTION
## Summary

Add a `notify-index` job to the riscv64 build workflow that triggers
index regeneration in `gounthar/riscv64-python-wheels` after a new
wheel release is published.

This ensures the PEP 503 package index at
https://gounthar.github.io/riscv64-python-wheels/simple/ is updated
immediately when new wheels become available, rather than waiting for
the daily cron.

## Changes

- Add `notify-index` job that sends `repository_dispatch` to the
  central wheels repo after the `release` job succeeds